### PR TITLE
feat: add Ubuntu 24.04 driver with auto-detection in setup_host.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+drivers/*.deb filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Python SDK and ROS2 driver for [XvisioTech](https://www.xvisiotech.com/) devices
 
 The `xvisio` Python package provides direct access to pose, IMU, and controller data — no ROS required.
 
-**1. One-time host setup** (installs udev rules and the XVSDK driver, requires Ubuntu 22.04):
+**1. One-time host setup** (installs udev rules and the XVSDK driver — auto-selected for Ubuntu 22.04 or 24.04):
 
 ```bash
 git clone https://github.com/robodreamer/xvisiotech_camera_examples.git

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Ubuntu 22.04 (x86_64)
+- Ubuntu 22.04 or 24.04 (x86_64)
 - Python 3.10+
 - XvisioTech device connected via USB (camera) or USB dongle (Seer controller)
 
@@ -46,7 +46,7 @@ The manual steps below are equivalent if you prefer not to use the script.
 
 ### Manual steps
 
-**1. One-time host setup** (installs udev rules, SuiteSparse, and the XVSDK `.deb`):
+**1. One-time host setup** (installs udev rules and the XVSDK driver — auto-selected for your Ubuntu version):
 
 ```bash
 git clone https://github.com/robodreamer/xvisiotech_camera_examples.git

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -1,0 +1,61 @@
+# XVSDK Drivers
+
+Pre-built XVSDK `.deb` packages for Ubuntu. The `setup_host.sh` script selects the right one automatically via `lsb_release -cs`.
+
+## Available drivers
+
+| File | Ubuntu target | XVSDK version |
+|------|--------------|---------------|
+| `XVSDK_jammy_amd64_20250227.deb` | 22.04 (Jammy) | 3.x |
+| `XVSDK_noble_amd64_20260406.deb` | 24.04 (Noble) | 3.2.0 |
+
+> **Note on `noble` filename:** The original file from the vendor was named `XVSDK_bionic_amd64_20260406.deb`.
+> glibc symbol analysis (max required: `GLIBC_2.25`) confirmed it is an Ubuntu 18.04-era build, but the
+> vendor confirmed it is supported on Ubuntu 24.04. It was renamed to `noble` so the setup script can
+> auto-select it correctly.
+
+## Driver differences (noble vs jammy)
+
+### New in noble
+
+**IR Tracking Camera support** — the most significant addition:
+- New `IrTrackingCamera` class with dual IR camera streaming, LED control, exposure time and temperature APIs
+- New types: `IrTrackingImage`, `IrTrackingTemperature`
+- C interface additions: `xv_start_irtracking()`, `xv_stop_irtracking()`, `xv_get_irtracking_image()` and camera2 equivalents
+
+**New parameter structs:**
+- `ExposureParam` (time in µs + gain) — now exposed on color and fisheye cameras via `getExposure()`
+- `ResolutionParam`, `RoiParam` — resolution and ROI query on IR tracking camera
+- `ClampData` — timestamped clamp/sync data, with `ClampStream` interface
+
+**New fisheye/stereo controls:**
+- `enableIrGamma(bool)` and `isEnableIrGamma()` on the stereo camera
+
+**Bundled SuiteSparse** — the noble driver ships its own copies of:
+`libamd`, `libblas`, `libcamd`, `libccolamd`, `libcholmod`, `libcolamd`, `libcxsparse`,
+`libgfortran`, `liblapack`, `libmetis`, `libspqr`, `libsuitesparseconfig`
+
+This means `libsuitesparse-dev` does **not** need to be installed separately on noble.
+`setup_host.sh` detects this automatically.
+
+**New C-interface types:**
+- `RGBD_Image`, `RGBPointcloud_Image` structs + callback typedefs
+- `libxvisio-CInterface-multi-wrapper.so` (multi-device C wrapper)
+
+### Removed in noble (present in jammy)
+- `/usr/bin/multi-devices`, `/usr/bin/multi-devices-c-interface`, `/usr/bin/player`, `/usr/bin/recorder` prebuilt demo binaries
+
+## Python API and example compatibility
+
+The existing Python API (`python/xvisio/`) and all examples are **fully compatible** with both drivers.
+
+The C++ wrapper (`cpp_core/`) only calls four SDK interfaces — `slam()`, `imuSensor()`, `fisheyeCameras()`, `wirelessController()` — none of which changed between jammy and noble. All noble driver additions are purely additive (new `IrTrackingCamera` class, new parameter structs, new methods on existing classes). The wrapper consumes `xv::Device` objects from the SDK; it does not subclass any SDK interfaces, so the new pure-virtual method additions have no impact.
+
+If new noble-only features (e.g. IR tracking camera, exposure control) are to be exposed in Python in the future, they can be added to `cpp_core/` and `python_bindings/` without affecting the existing API surface.
+
+## Adding a driver for a new Ubuntu release
+
+1. Name the file `XVSDK_<codename>_amd64_<date>.deb` where `<codename>` matches `lsb_release -cs` output (e.g. `oracular`, `plucky`).
+2. Add it to git via LFS (tracked automatically by `.gitattributes`): `git add drivers/XVSDK_<codename>_amd64_<date>.deb`
+3. No changes to `setup_host.sh` are needed — it discovers drivers by codename glob.
+4. If the new driver bundles SuiteSparse (check: `dpkg-deb --fsys-tarfile <file> | tar -t | grep libcholmod`), the script will skip the system install automatically.

--- a/drivers/XVSDK_noble_amd64_20260406.deb
+++ b/drivers/XVSDK_noble_amd64_20260406.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24dd59b314dc31fc3225658d3efdff755646588b2e5a2d72670af15febff1b69
+size 43692140

--- a/scripts/setup_host.sh
+++ b/scripts/setup_host.sh
@@ -16,9 +16,32 @@ fi
 
 UDEV_RULES_SRC="${DRIVERS_DIR}/99-xvisio.rules"
 UDEV_RULES_DEST="/etc/udev/rules.d/99-xvisio.rules"
-DEB_FILE="${DRIVERS_DIR}/XVSDK_jammy_amd64_20250227.deb"
 
 echo "=== Xvisio Host Setup ==="
+echo ""
+
+# Detect Ubuntu codename and select matching driver
+if ! command -v lsb_release &>/dev/null; then
+    echo "ERROR: lsb_release not found. Cannot detect Ubuntu version."
+    echo "Install it with: sudo apt-get install lsb-release"
+    exit 1
+fi
+
+UBUNTU_CODENAME=$(lsb_release -cs)
+echo "Detected Ubuntu codename: ${UBUNTU_CODENAME}"
+
+# Find driver matching this Ubuntu release (e.g. XVSDK_jammy_amd64_*.deb)
+DEB_FILE=$(ls "${DRIVERS_DIR}/XVSDK_${UBUNTU_CODENAME}_amd64_"*.deb 2>/dev/null | head -n1)
+
+if [ -z "${DEB_FILE}" ]; then
+    echo ""
+    echo "ERROR: No XVSDK driver found for Ubuntu '${UBUNTU_CODENAME}'."
+    echo "Available drivers in ${DRIVERS_DIR}:"
+    ls "${DRIVERS_DIR}"/XVSDK_*_amd64_*.deb 2>/dev/null | sed 's|.*/||' || echo "  (none)"
+    exit 1
+fi
+
+echo "Selected driver: $(basename "${DEB_FILE}")"
 echo ""
 
 # Check if running as root or with sudo
@@ -59,11 +82,14 @@ else
     echo "  NOTE: You may need to log out and log back in for group changes to take effect"
 fi
 
-# Step 3: Install SuiteSparse (required for stub generation and XVSDK dependencies)
+# Step 3: Install SuiteSparse if not bundled in the driver
+# Newer drivers (noble+) bundle SuiteSparse .so files directly; older drivers rely on the system package.
 echo ""
-echo "[3/4] Installing SuiteSparse libraries..."
-if dpkg -l | grep -q "libsuitesparse-dev"; then
-    echo "SuiteSparse already installed"
+echo "[3/4] Checking SuiteSparse..."
+if dpkg-deb --fsys-tarfile "${DEB_FILE}" | tar -t | grep -q "libcholmod.so"; then
+    echo "✓ SuiteSparse bundled in driver — skipping system install"
+elif dpkg -l | grep -q "libsuitesparse-dev"; then
+    echo "✓ SuiteSparse already installed"
 else
     apt-get install -y libsuitesparse-dev
     echo "✓ SuiteSparse libraries installed"
@@ -100,8 +126,8 @@ echo "=== Setup Complete ==="
 echo ""
 echo "Installed packages:"
 echo "  - udev rules for device access"
-echo "  - SuiteSparse libraries (for stub generation)"
-echo "  - XVSDK driver"
+echo "  - SuiteSparse libraries (system or bundled in driver)"
+echo "  - XVSDK driver: $(basename "${DEB_FILE}")"
 echo ""
 echo "Next steps:"
 echo "1. If you were added to the plugdev group, log out and log back in"


### PR DESCRIPTION
- Add XVSDK_noble_amd64_20260406.deb for Ubuntu 24.04 (Noble) via git-lfs
- Migrate XVSDK_jammy_amd64_20250227.deb to git-lfs (.gitattributes)
- setup_host.sh now detects Ubuntu codename via lsb_release and selects the matching XVSDK_<codename>_amd64_*.deb automatically; fails with a clear error listing available drivers if no match is found
- SuiteSparse install step skipped when driver bundles libcholmod.so (noble driver bundles SuiteSparse; jammy driver relies on system package)
- Add drivers/README.md documenting driver differences, compatibility notes, and instructions for adding future Ubuntu release drivers
- Update docs/installation.md and README.md: Ubuntu 24.04 support, updated setup_host.sh description, fix stale .deb filename reference