### PR TITLE
fix: auto-install Python 3.10+ if system Python is too old

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ site/
 .DS_Store
 Thumbs.db
 
+# Playwright MCP
+.playwright-mcp/
+

--- a/scripts/install_xvisio_linux.sh
+++ b/scripts/install_xvisio_linux.sh
@@ -89,7 +89,51 @@ else
   echo "Skipping host setup (--skip-host-setup)."
 fi
 
-# ── Step 2: Python virtual environment ────────────────────────────────────────
+# ── Step 2: Python version check ─────────────────────────────────────────────
+step "Checking Python version"
+
+py_version_ok() {
+  local py="$1"
+  local major minor
+  major=$("$py" -c "import sys; print(sys.version_info.major)" 2>/dev/null) || return 1
+  minor=$("$py" -c "import sys; print(sys.version_info.minor)" 2>/dev/null) || return 1
+  [[ "$major" -gt 3 || ( "$major" -eq 3 && "$minor" -ge 10 ) ]]
+}
+
+if ! command -v "$PYTHON" &>/dev/null; then
+  red "ERROR: Python interpreter not found: $PYTHON"
+  exit 1
+fi
+
+if ! py_version_ok "$PYTHON"; then
+  PY_VERSION=$("$PYTHON" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+  echo "Python $PY_VERSION is too old (xvisio requires >= 3.10). Looking for a newer version..."
+
+  FOUND_PY=""
+  for candidate in python3.12 python3.11 python3.10; do
+    if command -v "$candidate" &>/dev/null && py_version_ok "$candidate"; then
+      FOUND_PY="$candidate"
+      break
+    fi
+  done
+
+  if [[ -n "$FOUND_PY" ]]; then
+    echo "Found $FOUND_PY — switching to it."
+    PYTHON="$FOUND_PY"
+  else
+    echo "No suitable Python found. Installing Python 3.10 via deadsnakes PPA..."
+    sudo apt-get install -y software-properties-common
+    sudo add-apt-repository -y ppa:deadsnakes/ppa
+    sudo apt-get update -q
+    sudo apt-get install -y python3.10 python3.10-venv python3.10-distutils
+    PYTHON="python3.10"
+  fi
+fi
+
+PY_VERSION=$("$PYTHON" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+green "✓ Python $PY_VERSION ($PYTHON)"
+
+# ── Step 3: Python virtual environment ────────────────────────────────────────
 step "Python virtual environment"
 if [[ ! -d "$VENV_DIR" ]]; then
   "$PYTHON" -m venv "$VENV_DIR"
@@ -102,7 +146,17 @@ fi
 source "${VENV_DIR}/bin/activate"
 pip install -U pip -q
 
-# ── Step 3: Install xvisio ────────────────────────────────────────────────────
+# ── Step 4: Check C++ compiler ───────────────────────────────────────────────
+step "Checking C++ compiler"
+if ! dpkg -l build-essential 2>/dev/null | grep -q "^ii"; then
+  echo "build-essential not found — installing..."
+  sudo apt-get install -y build-essential
+  green "✓ build-essential installed"
+else
+  echo "C++ compiler already present."
+fi
+
+# ── Step 5: Install xvisio ────────────────────────────────────────────────────
 step "Installing xvisio"
 if [[ "$EDITABLE" == true ]]; then
   if [[ "$IN_REPO" == false ]]; then
@@ -116,7 +170,7 @@ else
   green "✓ Installed xvisio from PyPI"
 fi
 
-# ── Step 4: Verify ────────────────────────────────────────────────────────────
+# ── Step 6: Verify ────────────────────────────────────────────────────────────
 step "Verifying installation"
 python -c "import xvisio; print('xvisio', xvisio.__version__)"
 green "✓ Installation complete"


### PR DESCRIPTION
This pull request improves the robustness of the `scripts/install_xvisio_linux.sh` installation script by adding checks for Python and C++ compiler prerequisites before proceeding with the installation. The script now ensures that a suitable Python version is available (and installs one if needed), verifies the presence of a C++ compiler, and adjusts the step numbering for clarity.

**Python environment setup improvements:**

* Added a Python version check to ensure Python >= 3.10 is used; if not found, the script searches for or installs an appropriate version using deadsnakes PPA. (`scripts/install_xvisio_linux.sh`)

**Compiler prerequisites:**

* Added a check for the presence of the `build-essential` package (C++ compiler); installs it if missing to ensure build dependencies are met. (`scripts/install_xvisio_linux.sh`)

**Script organization and clarity:**

* Updated step numbering and comments to reflect the new prerequisite checks and maintain logical flow throughout the script. 