### PR TITLE
Add EmbodiK teleop installer option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 - `scripts/install_xvisio_linux.sh` now recreates incomplete virtual environments instead of failing later at `source .venv/bin/activate`.
+- `scripts/install_xvisio_linux.sh --teleop` now installs EmbodiK solver/example support into the same virtual environment for Panda teleop.
+- `scripts/install_xvisio_linux.sh --teleop` now uses a clean PyPI `pin` build path and persists the matching runtime library path for EmbodiK's COAL/Pinocchio dependencies.
+- Standalone `scripts/install_xvisio_linux.sh` runs now download only the host setup script and driver assets by default, with `--host-assets clone` available for the full temporary clone path.
 
 #### Changed
 - Installation docs now recommend creating a clean virtual environment before `pip install xvisio`.
 - Troubleshooting docs now clarify that `pip` hash-mismatch errors usually come from local/system `pip` configuration rather than this repository's package metadata.
+- Added a `teleop` optional dependency and docs for installing EmbodiK solver/example support in the same `xvisio` virtual environment.
 
 ### [0.4.0] - 2026-03-30
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,26 @@ pip install -U pip
 pip install xvisio
 ```
 
+If you want EmbodiK's Panda teleop example support, the one-shot installer can
+add it to the same environment:
+
+```bash
+curl -fsSL -O https://gist.githubusercontent.com/robodreamer/fb7db4b86c9e63f8737da32ee6f9e98f/raw/install_xvisio_linux.sh
+bash install_xvisio_linux.sh --teleop                 # fresh install, no repo clone
+# or, after the manual xvisio setup above:
+bash scripts/install_xvisio_linux.sh --skip-host-setup --teleop
+source .venv/bin/activate
+embodik-examples --copy
+cd embodik_examples
+python 03_teleop_ik.py --robot panda
+# Seer controller only: add --controller-port /dev/ttyUSB0 if needed
+```
+
 If you prefer a one-shot Ubuntu installer that also creates the virtual environment for you, use:
 
 ```bash
-bash scripts/install_xvisio_linux.sh
+curl -fsSL -O https://gist.githubusercontent.com/robodreamer/fb7db4b86c9e63f8737da32ee6f9e98f/raw/install_xvisio_linux.sh
+bash install_xvisio_linux.sh
 ```
 
 **3. Run:**

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,27 @@
 
 ### One-shot installer
 
-From a clone of this repository (recommended):
+From a fresh folder, download the public installer script and run it:
+
+```bash
+curl -fsSL -O https://gist.githubusercontent.com/robodreamer/fb7db4b86c9e63f8737da32ee6f9e98f/raw/install_xvisio_linux.sh
+bash install_xvisio_linux.sh
+
+# Or install xvisio plus EmbodiK solver/example support for Panda teleop
+bash install_xvisio_linux.sh --teleop
+```
+
+The standalone installer creates `./.venv`, installs `xvisio` from PyPI, and
+downloads only the host setup assets required for Xvisio hardware support
+(`setup_host.sh`, the udev rules, and the XVSDK `.deb`). It does not clone the
+full repository by default. If you prefer the previous full-checkout behavior
+for host setup assets, pass `--host-assets clone`:
+
+```bash
+bash install_xvisio_linux.sh --host-assets clone
+```
+
+From a clone of this repository:
 
 ```bash
 # PyPI install into ./.venv in your current directory
@@ -18,6 +38,9 @@ bash scripts/install_xvisio_linux.sh
 
 # Use a specific Python and venv path
 bash scripts/install_xvisio_linux.sh --python python3.12 --venv ./.venv
+
+# Also install EmbodiK solver/example support for Panda teleop
+bash scripts/install_xvisio_linux.sh --teleop
 
 # Editable install from the repo
 bash scripts/install_xvisio_linux.sh --editable
@@ -27,18 +50,6 @@ bash scripts/install_xvisio_linux.sh --skip-host-setup
 ```
 
 Run `bash scripts/install_xvisio_linux.sh --help` for all options.
-
-Without cloning, you can download the script and run it from an empty project folder
-(it will clone the repo to a temp dir to fetch the XVSDK driver, then install **xvisio from PyPI**):
-
-```bash
-curl -fsSL -O https://gist.githubusercontent.com/robodreamer/fb7db4b86c9e63f8737da32ee6f9e98f/raw/33e032d5e9576964131b8bd49e3fae4ad5d501d9/install_xvisio_linux.sh
-bash install_xvisio_linux.sh
-```
-
-!!! note "Why a clone is needed"
-    Unlike pure-Python packages, the host setup requires the **XVSDK driver `.deb`** from `drivers/`.
-    When run without a clone, the installer clones the repo to a temporary directory automatically.
 
 The manual steps below are equivalent if you prefer not to use the script.
 
@@ -66,6 +77,10 @@ sudo ./scripts/setup_host.sh
 
     # Optional: includes viser for 3D visualization examples
     pip install xvisio[examples]
+
+    # Optional shorthand: adds the EmbodiK solver and example dependencies for teleop
+    # See "Running the EmbodiK Panda Teleop Example" below if EmbodiK builds from source.
+    pip install "xvisio[teleop]"
     ```
 
     View the package at [pypi.org/project/xvisio/](https://pypi.org/project/xvisio/).
@@ -116,6 +131,59 @@ xvisio-examples --copy
 cd xvisio_examples
 python demo_pose_imu.py
 ```
+
+## Running the EmbodiK Panda Teleop Example
+
+The EmbodiK teleop example (`03_teleop_ik.py`) can reuse the same virtual
+environment that contains `xvisio`. The one-shot installer can add EmbodiK's
+native solver package, example dependencies, and Linux build prerequisites to
+that environment. During `--teleop`, the installer uses a clean PyPI `pin`
+build environment and persists the matching `cmeel.prefix/lib` runtime library
+path into the venv activation script so EmbodiK can find COAL/Pinocchio shared
+libraries after `source .venv/bin/activate`:
+
+```bash
+# Fresh xvisio + teleop install
+bash scripts/install_xvisio_linux.sh --teleop
+
+# Or add teleop support to an existing xvisio venv from the manual steps above
+bash scripts/install_xvisio_linux.sh --skip-host-setup --teleop
+
+source .venv/bin/activate
+embodik-examples --copy
+cd embodik_examples
+python 03_teleop_ik.py --robot panda
+```
+
+If you are installing manually instead of using the script, mirror the EmbodiK
+Linux installer setup before installing the solver package:
+
+```bash
+sudo apt-get install -y \
+  build-essential cmake ninja-build pkg-config \
+  libeigen3-dev liburdfdom-dev
+
+pip install pin scikit-build-core nanobind cmake ninja
+export CMAKE_PREFIX_PATH="$(python -c 'import pinocchio, pathlib; print(pathlib.Path(pinocchio.__file__).resolve().parents[4])')"
+pip install --no-build-isolation "embodik[examples]"
+```
+
+If your environment can install a prebuilt EmbodiK wheel, `pip install
+"xvisio[teleop]"` is the shorter equivalent for adding the EmbodiK solver and
+example dependencies, but the one-shot `--teleop` path is recommended when you
+have local ROS, Pinocchio, Boost, or COAL builds in your shell environment.
+
+For Seer wireless controller input, the EmbodiK example opens the controller
+through a serial device. It defaults to `/dev/ttyUSB0`; pass another
+`--controller-port` only if your controller enumerates differently:
+
+```bash
+python 03_teleop_ik.py --robot panda --controller-port /dev/ttyUSB1
+```
+
+For tracking-camera input, no `/dev/ttyUSB*` controller port is needed; use the
+tracking-camera-specific command or options provided by the EmbodiK teleop
+example you are running.
 
 ## Troubleshooting
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -75,3 +75,4 @@ with xvisio.open() as dev:
 - [Pose Transforms Example](examples/pose_transforms.md) — Raw vs world-aligned vs relative poses
 - [Pose + IMU Example](examples/pose_imu.md) — Complete demo script with error handling
 - [3D Visualization Example](examples/visualization.md) — Live pose visualization in the browser
+- [Installation Guide](installation.md#running-the-embodik-panda-teleop-example) — Install EmbodiK solver support and run Panda teleop from the same `xvisio` venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ keywords = ["robotics", "slam", "imu", "tracking", "xvisio"]
 [project.optional-dependencies]
 visualization = ["viser>=1.0.0"]
 examples = ["viser>=1.0.0"]
+teleop = ["embodik[examples]>=0.20.0"]
 
 [project.scripts]
 xvisio-setup = "xvisio.cli:setup_host"

--- a/python/README.md
+++ b/python/README.md
@@ -29,6 +29,20 @@ pip install -U pip
 pip install xvisio
 ```
 
+Optional: install the EmbodiK solver plus its example dependencies into the
+same virtual environment to run the Panda teleop example:
+
+```bash
+bash scripts/install_xvisio_linux.sh --teleop          # fresh install
+# or, after the manual xvisio setup above:
+bash scripts/install_xvisio_linux.sh --skip-host-setup --teleop
+source .venv/bin/activate
+embodik-examples --copy
+cd embodik_examples
+python 03_teleop_ik.py --robot panda
+# Seer controller only: add --controller-port /dev/ttyUSB0 if needed
+```
+
 ### 3. Run demo
 
 ```bash

--- a/scripts/install_xvisio_linux.sh
+++ b/scripts/install_xvisio_linux.sh
@@ -5,6 +5,7 @@
 #   bash scripts/install_xvisio_linux.sh
 #   bash scripts/install_xvisio_linux.sh --python python3.12 --venv ./.venv
 #   bash scripts/install_xvisio_linux.sh --editable
+#   bash scripts/install_xvisio_linux.sh --teleop
 #
 # Usage (without cloning — installs xvisio from PyPI):
 #   curl -fsSL -O <GIST_URL>/install_xvisio_linux.sh
@@ -14,11 +15,16 @@
 #   1. Installs system packages (udev rules + XVSDK driver) using setup_host.sh
 #   2. Creates a Python virtual environment
 #   3. Installs xvisio from PyPI (or editable from a local clone)
+#   4. Optionally installs EmbodiK solver/example support for teleop
+#   When run outside a clone, it downloads only the host setup script and driver
+#   assets needed for step 1 instead of cloning the full repository.
 #
 # Flags:
 #   --python PATH      Python interpreter to use (default: python3)
 #   --venv   PATH      Virtual environment path (default: ./.venv)
 #   --editable         Editable install from repo (default: pip install xvisio)
+#   --teleop           Also install EmbodiK solver/example dependencies for teleop
+#   --host-assets MODE Host setup asset source when outside a clone: minimal (default) or clone
 #   --skip-host-setup  Skip sudo setup_host.sh (udev rules + XVSDK driver)
 #   --help             Show this help message
 
@@ -27,8 +33,11 @@ set -euo pipefail
 PYTHON="${PYTHON:-python3}"
 VENV_DIR="./.venv"
 EDITABLE=false
+INSTALL_TELEOP=false
 SKIP_HOST_SETUP=false
+HOST_ASSETS_MODE="minimal"
 REPO_URL="https://github.com/robodreamer/xvisiotech_camera_examples.git"
+RAW_BASE_URL="https://raw.githubusercontent.com/robodreamer/xvisiotech_camera_examples/main"
 TMP_CLONE=""
 
 # ── Argument parsing ─────────────────────────────────────────────────────────
@@ -37,6 +46,15 @@ while [[ $# -gt 0 ]]; do
     --python)   PYTHON="$2";           shift 2 ;;
     --venv)     VENV_DIR="$2";         shift 2 ;;
     --editable) EDITABLE=true;         shift   ;;
+    --teleop)   INSTALL_TELEOP=true;   shift   ;;
+    --host-assets)
+      HOST_ASSETS_MODE="$2"
+      if [[ "$HOST_ASSETS_MODE" != "minimal" && "$HOST_ASSETS_MODE" != "clone" ]]; then
+        echo "ERROR: --host-assets must be 'minimal' or 'clone'" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
     --skip-host-setup) SKIP_HOST_SETUP=true; shift ;;
     --help|-h)
       grep '^#' "$0" | sed 's/^# \?//'
@@ -51,6 +69,50 @@ green() { printf '\033[32m%s\033[0m\n' "$*"; }
 red()   { printf '\033[31m%s\033[0m\n' "$*" >&2; }
 step()  { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
 
+download_file() {
+  local url="$1"
+  local dest="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$dest"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$url" -O "$dest"
+  else
+    red "ERROR: Need curl or wget to download host setup assets."
+    exit 1
+  fi
+}
+
+download_host_setup_assets() {
+  local dest="$1"
+  mkdir -p "${dest}/scripts" "${dest}/drivers"
+
+  echo "Downloading host setup assets from ${RAW_BASE_URL}..."
+  download_file "${RAW_BASE_URL}/scripts/setup_host.sh" "${dest}/scripts/setup_host.sh"
+  download_file "${RAW_BASE_URL}/drivers/99-xvisio.rules" "${dest}/drivers/99-xvisio.rules"
+  download_file "${RAW_BASE_URL}/drivers/XVSDK_jammy_amd64_20250227.deb" \
+    "${dest}/drivers/XVSDK_jammy_amd64_20250227.deb"
+  chmod +x "${dest}/scripts/setup_host.sh"
+}
+
+persist_teleop_runtime_env() {
+  local activate_file="${VENV_DIR}/bin/activate"
+  local lib_dir="$1"
+  local begin_marker="# >>> xvisio teleop runtime env >>>"
+  local end_marker="# <<< xvisio teleop runtime env <<<"
+
+  if [[ ! -f "$activate_file" ]]; then
+    return
+  fi
+
+  sed -i "/${begin_marker}/,/${end_marker}/d" "$activate_file"
+  cat >> "$activate_file" <<EOF
+
+${begin_marker}
+export LD_LIBRARY_PATH="${lib_dir}\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}"
+${end_marker}
+EOF
+}
+
 cleanup() {
   if [[ -n "$TMP_CLONE" && -d "$TMP_CLONE" ]]; then
     rm -rf "$TMP_CLONE"
@@ -58,12 +120,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# ── Guard: must not run inside an active venv ────────────────────────────────
+# ── Guard: avoid accidentally installing into the wrong active venv ──────────
 if [[ -n "${VIRTUAL_ENV:-}" ]]; then
-  red "ERROR: A virtual environment is currently active ($VIRTUAL_ENV)."
-  red "Please deactivate it first:  deactivate"
-  red "Then re-run this script."
-  exit 1
+  ACTIVE_VENV="$(readlink -f "$VIRTUAL_ENV")"
+  TARGET_VENV="$(readlink -m "$VENV_DIR")"
+  if [[ "$ACTIVE_VENV" != "$TARGET_VENV" ]]; then
+    red "ERROR: A different virtual environment is currently active ($VIRTUAL_ENV)."
+    red "Target venv for this install is: $VENV_DIR"
+    red "Please deactivate it first:  deactivate"
+    red "Then re-run this script, or pass --venv \"$VIRTUAL_ENV\" to update the active environment."
+    exit 1
+  fi
+  echo "Using active target virtual environment: $VIRTUAL_ENV"
 fi
 
 # ── Detect repo context ───────────────────────────────────────────────────────
@@ -85,10 +153,16 @@ if [[ "$SKIP_HOST_SETUP" == false ]]; then
     # Running from inside the cloned repo
     sudo bash "${REPO_ROOT}/scripts/setup_host.sh"
   else
-    # Running standalone (downloaded via curl) — clone repo to temp dir first
-    echo "No local clone detected. Cloning repo to a temporary directory..."
     TMP_CLONE="$(mktemp -d)"
-    git clone --depth=1 "$REPO_URL" "$TMP_CLONE"
+    if [[ "$HOST_ASSETS_MODE" == "clone" ]]; then
+      # Running standalone, but user requested the full repository checkout.
+      echo "No local clone detected. Cloning repo to a temporary directory..."
+      git clone --depth=1 "$REPO_URL" "$TMP_CLONE"
+    else
+      # Running standalone (downloaded via curl) — download only required host assets.
+      echo "No local clone detected. Downloading setup_host.sh and driver assets..."
+      download_host_setup_assets "$TMP_CLONE"
+    fi
     sudo bash "${TMP_CLONE}/scripts/setup_host.sh"
   fi
 
@@ -197,12 +271,58 @@ else
   green "✓ Installed xvisio from PyPI"
 fi
 
-# ── Step 6: Verify ────────────────────────────────────────────────────────────
+# ── Step 6: Optional EmbodiK teleop support ───────────────────────────────────
+if [[ "$INSTALL_TELEOP" == true ]]; then
+  step "Installing EmbodiK teleop support"
+  echo "Installing EmbodiK system dependencies..."
+  sudo apt-get install -y \
+    build-essential \
+    cmake \
+    ninja-build \
+    pkg-config \
+    libeigen3-dev \
+    liburdfdom-dev
+
+  echo "Installing EmbodiK Python build dependencies into ${VENV_DIR}..."
+  pip install pin scikit-build-core nanobind cmake ninja
+
+  echo "Configuring clean EmbodiK build/runtime paths from the PyPI pin wheel..."
+  unset LD_LIBRARY_PATH DYLD_LIBRARY_PATH CMAKE_PREFIX_PATH pinocchio_DIR || true
+  PIN_PREFIX="$(python -c 'import pinocchio, pathlib; print(pathlib.Path(pinocchio.__file__).resolve().parents[4])')"
+  CMEEL_LIB_DIR="${PIN_PREFIX}/lib"
+  export CMAKE_PREFIX_PATH="${PIN_PREFIX}"
+  export LD_LIBRARY_PATH="${CMEEL_LIB_DIR}"
+  echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
+  echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+  persist_teleop_runtime_env "$CMEEL_LIB_DIR"
+
+  echo "Installing EmbodiK solver and example dependencies..."
+  pip install --no-build-isolation "embodik[examples]"
+  python -c "import embodik; print('embodik', embodik.__version__)"
+  green "✓ EmbodiK teleop support installed"
+fi
+
+# ── Step 7: Verify ────────────────────────────────────────────────────────────
 step "Verifying installation"
 python -c "import xvisio; print('xvisio', xvisio.__version__)"
 green "✓ Installation complete"
 
-cat <<'EOF'
+if [[ "$INSTALL_TELEOP" == true ]]; then
+  cat <<'EOF'
+
+Next steps:
+  1. If added to plugdev group above, log out and log back in
+  2. Connect your Xvisio tracking camera or Seer controller
+  3. Activate the venv:
+       source .venv/bin/activate
+  4. Copy and run the EmbodiK Panda teleop example:
+       embodik-examples --copy
+       cd embodik_examples
+       python 03_teleop_ik.py --robot panda
+     Seer controller only: add --controller-port /dev/ttyUSB0 if needed
+EOF
+else
+  cat <<'EOF'
 
 Next steps:
   1. If added to plugdev group above, log out and log back in
@@ -211,3 +331,4 @@ Next steps:
        source .venv/bin/activate
        python -c "import xvisio; print(xvisio.discover())"
 EOF
+fi


### PR DESCRIPTION
This pull request adds optional EmbodiK solver and Panda teleop example support to the Xvisio installation process, making it possible to install and run EmbodiK-based teleoperation examples directly from the same virtual environment as `xvisio`. The changes update the installer script, documentation, and packaging to support a new `--teleop` flag and dependency group, and clarify how host setup assets are fetched in minimal vs. full-clone modes. The documentation now guides users through both standard and teleop-enhanced installations.

**Installer and Teleop Support Enhancements:**

* Added a `--teleop` flag to `scripts/install_xvisio_linux.sh` to install EmbodiK solver, example dependencies, and required system packages for Panda teleop, including runtime environment setup for COAL/Pinocchio libraries. The script can now fetch only minimal host setup assets or perform a full repo clone as needed (`--host-assets minimal|clone`). 

* The installer now guards against activating or modifying the wrong virtual environment, and persists necessary runtime environment variables for EmbodiK teleop support.

**Packaging and Dependency Updates:**

* Added a new optional dependency group `teleop` in `pyproject.toml` for EmbodiK teleop support (`embodik[examples]>=0.20.0`).

**Documentation Improvements:**

* Updated `README.md`, `python/README.md`, and `docs/installation.md` to document the new teleop installation workflow, including usage of the one-shot installer, manual steps, and how to run the EmbodiK Panda teleop example. Clarified the difference between minimal asset download and full repo clone for host setup. 
* Added references in `docs/quickstart.md` to the new EmbodiK teleop installation guide.

**Changelog Updates:**

* Updated `CHANGELOG.md` to document the new teleop support, installer improvements, and documentation changes.